### PR TITLE
feat: add mobile auth ui

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,14 +1,19 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import App from './App'
 
-test('renders Meetinity title', () => {
-  render(<App />)
-  const titleElement = screen.getByText(/Meetinity Mobile App/i)
-  expect(titleElement).toBeInTheDocument()
+beforeEach(() => {
+  localStorage.clear()
 })
 
-test('renders features list', () => {
+test('shows auth when not authenticated', () => {
   render(<App />)
-  const swipeFeature = screen.getByText(/Swipe profiles/i)
-  expect(swipeFeature).toBeInTheDocument()
+  expect(screen.getByText(/Sign in with Google/i)).toBeInTheDocument()
+})
+
+test('sign in stores token and shows home', () => {
+  render(<App />)
+  fireEvent.click(screen.getByText(/Sign in with Google/i))
+  expect(localStorage.getItem('authToken')).toBe('google-mock-token')
+  expect(screen.getByText(/Meetinity Mobile App/i)).toBeInTheDocument()
+  expect(screen.getByText(/Swipe profiles/i)).toBeInTheDocument()
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,16 @@
-import React from 'react'
+import React, { useState } from 'react'
+import Home from './Home'
+import Auth from './Auth'
 
 function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <h1>Meetinity Mobile App</h1>
-        <p>Professional networking app</p>
-        <div className="features">
-          <h2>Features:</h2>
-          <ul>
-            <li>Swipe profiles</li>
-            <li>Match with professionals</li>
-            <li>Attend networking events</li>
-            <li>Chat with matches</li>
-          </ul>
-        </div>
-      </header>
-    </div>
-  )
+  const [token, setToken] = useState<string | null>(localStorage.getItem('authToken'))
+
+  const handleAuth = (newToken: string) => {
+    localStorage.setItem('authToken', newToken)
+    setToken(newToken)
+  }
+
+  return token ? <Home /> : <Auth onAuth={handleAuth} />
 }
 
 export default App

--- a/src/Auth.test.tsx
+++ b/src/Auth.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import Auth from './Auth'
+
+test('renders sign in options', () => {
+  render(<Auth onAuth={() => {}} />)
+  expect(screen.getByText(/Sign in with Google/i)).toBeInTheDocument()
+  expect(screen.getByText(/Sign in with LinkedIn/i)).toBeInTheDocument()
+})
+
+test('calls onAuth with provider token', () => {
+  const handleAuth = vi.fn()
+  render(<Auth onAuth={handleAuth} />)
+  fireEvent.click(screen.getByText(/Sign in with Google/i))
+  expect(handleAuth).toHaveBeenCalledWith('google-mock-token')
+})

--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import './index.css'
+
+interface AuthProps {
+  onAuth: (token: string) => void
+}
+
+const Auth: React.FC<AuthProps> = ({ onAuth }) => {
+  const handleAuth = (provider: 'google' | 'linkedin') => {
+    const token = `${provider}-mock-token`
+    onAuth(token)
+  }
+
+  return (
+    <div className="auth-container">
+      <h1>Sign In</h1>
+      <button onClick={() => handleAuth('google')}>Sign in with Google</button>
+      <button onClick={() => handleAuth('linkedin')}>Sign in with LinkedIn</button>
+    </div>
+  )
+}
+
+export default Auth

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+function Home() {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <h1>Meetinity Mobile App</h1>
+        <p>Professional networking app</p>
+        <div className="features">
+          <h2>Features:</h2>
+          <ul>
+            <li>Swipe profiles</li>
+            <li>Match with professionals</li>
+            <li>Attend networking events</li>
+            <li>Chat with matches</li>
+          </ul>
+        </div>
+      </header>
+    </div>
+  )
+}
+
+export default Home

--- a/src/index.css
+++ b/src/index.css
@@ -35,3 +35,17 @@ body {
   padding: 10px;
   border-radius: 5px;
 }
+.auth-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.auth-container button {
+  width: 100%;
+  max-width: 300px;
+  padding: 0.75rem;
+  margin: 0.5rem 0;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- add auth screen with Google and LinkedIn options
- store auth token and switch between auth and home views
- test auth flow and token-driven navigation

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689b4aeee490833293177c7852aa629f