### PR TITLE
Refine OAuth token persistence handling

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import AuthService, { User } from '../services/AuthService'
 
 interface AuthContextType {
@@ -21,11 +21,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [token, setTokenState] = useState<string | null>(localStorage.getItem('authToken'))
   const [user, setUser] = useState<User | null>(null)
 
+  const logout = useCallback(() => {
+    localStorage.removeItem('authToken')
+    setTokenState(null)
+    setUser(null)
+  }, [])
+
   useEffect(() => {
     if (token) {
       AuthService.profile().then(setUser).catch(() => logout())
+    } else {
+      setUser(null)
     }
-  }, [token])
+  }, [token, logout])
 
   const login = async (provider: 'google' | 'linkedin') => {
     const url = await AuthService.getAuthUrl(provider)
@@ -35,14 +43,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const setToken = async (newToken: string) => {
     localStorage.setItem('authToken', newToken)
     setTokenState(newToken)
-    const profile = await AuthService.profile()
-    setUser(profile)
-  }
-
-  const logout = () => {
-    localStorage.removeItem('authToken')
-    setTokenState(null)
-    setUser(null)
   }
 
   return <AuthContext.Provider value={{ user, token, login, setToken, logout }}>{children}</AuthContext.Provider>

--- a/src/screens/OAuthCallback.tsx
+++ b/src/screens/OAuthCallback.tsx
@@ -14,10 +14,8 @@ const OAuthCallback: React.FC = () => {
     const state = params.get('state')
     if (code && state) {
       AuthService.handleCallback({ code, state })
-        .then(async (token) => {
-          await setToken(token)
-          navigate('/profile')
-        })
+        .then((token) => setToken(token))
+        .then(() => navigate('/profile'))
         .catch(() => navigate('/login'))
     } else {
       navigate('/login')


### PR DESCRIPTION
## Summary
- load the authenticated user profile exclusively from the token-driven effect
- persist tokens without extra profile calls and keep logout logic memoized in context
- adjust the OAuth callback flow and test to wait only for token storage before redirecting

## Testing
- node node_modules/vitest/vitest.mjs run src/screens/OAuthCallback.test.tsx *(fails: esbuild binary in node_modules targets win32)*

------
https://chatgpt.com/codex/tasks/task_e_68d78c0929b48332a45957cf43be7443