### PR TITLE
Fix profile draft hydration and edit flow

### DIFF
--- a/src/features/profile/hooks/useProfileDraft.ts
+++ b/src/features/profile/hooks/useProfileDraft.ts
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import localforage from 'localforage'
+import type {
+  ProfileCreatePayload,
+  ProfileDraft,
+  ProfileDraftHydration,
+  ProfilePreferencesUpdatePayload,
+  ProfileUpdatePayload,
+  UserProfile,
+} from '../types'
+
+const STORAGE_KEY = 'meetinity/profile-draft'
+
+const createEmptyDraft = (): ProfileDraft => ({
+  fullName: '',
+  headline: '',
+  bio: '',
+  interests: [],
+  location: '',
+  availability: '',
+  preferences: {
+    discoveryRadiusKm: 25,
+    industries: [],
+    interests: [],
+    eventTypes: [],
+    notifications: { matches: true, events: true, messages: true },
+    availabilityVisibility: 'connections',
+  },
+  updatedAt: new Date(0).toISOString(),
+})
+
+const profileToDraft = (profile: UserProfile): ProfileDraft => ({
+  fullName: profile.fullName,
+  headline: profile.headline,
+  bio: profile.bio ?? '',
+  interests: [...profile.interests],
+  location: profile.location ?? '',
+  availability: profile.availability ?? '',
+  preferences: {
+    discoveryRadiusKm: profile.preferences.discoveryRadiusKm,
+    industries: [...profile.preferences.industries],
+    interests: [...profile.preferences.interests],
+    eventTypes: [...profile.preferences.eventTypes],
+    notifications: { ...profile.preferences.notifications },
+    availabilityVisibility: profile.preferences.availabilityVisibility,
+  },
+  photo: profile.avatarUrl
+    ? {
+        avatarUrl: profile.avatarUrl,
+        avatarCacheKey: profile.avatarCacheKey,
+      }
+    : undefined,
+  updatedAt: profile.updatedAt,
+})
+
+const normalizePreferences = (
+  preferences: ProfileDraft['preferences'],
+): ProfilePreferencesUpdatePayload => ({
+  discoveryRadiusKm: preferences.discoveryRadiusKm,
+  industries: preferences.industries,
+  interests: preferences.interests,
+  eventTypes: preferences.eventTypes,
+  notifications: preferences.notifications,
+  availabilityVisibility: preferences.availabilityVisibility,
+})
+
+const isEqual = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b)
+
+interface UseProfileDraftOptions {
+  waitForProfile?: boolean
+}
+
+export const useProfileDraft = (profile?: UserProfile | null, options: UseProfileDraftOptions = {}) => {
+  const waitForProfile = options.waitForProfile ?? false
+  const [draft, setDraft] = useState<ProfileDraft>(() => (profile ? profileToDraft(profile) : createEmptyDraft()))
+  const [hydration, setHydration] = useState<ProfileDraftHydration>({ isHydrated: false })
+  const hydrationRef = useRef(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const hydrate = async () => {
+      try {
+        const stored = await localforage.getItem<ProfileDraft>(STORAGE_KEY)
+        if (cancelled) return
+        if (stored) {
+          setDraft(stored)
+          hydrationRef.current = true
+          setHydration({ isHydrated: true })
+          return
+        }
+
+        if (profile) {
+          setDraft(profileToDraft(profile))
+          hydrationRef.current = true
+          setHydration({ isHydrated: true })
+          return
+        }
+
+        if (!waitForProfile) {
+          hydrationRef.current = true
+          setHydration({ isHydrated: true })
+        }
+      } catch (error) {
+        console.error('Unable to hydrate profile draft', error)
+        hydrationRef.current = true
+        setHydration({ isHydrated: true, error: (error as Error).message })
+      }
+    }
+    void hydrate()
+    return () => {
+      cancelled = true
+    }
+  }, [profile?.id, waitForProfile])
+
+  useEffect(() => {
+    if (!hydrationRef.current) return
+    void localforage.setItem(STORAGE_KEY, draft)
+  }, [draft])
+
+  useEffect(() => {
+    if (!hydration.isHydrated || !profile) return
+
+    setDraft((current) => {
+      const profileUpdatedAt = Date.parse(profile.updatedAt ?? '')
+      const currentUpdatedAt = Date.parse(current.updatedAt ?? '')
+
+      if (
+        !Number.isNaN(profileUpdatedAt) &&
+        !Number.isNaN(currentUpdatedAt) &&
+        currentUpdatedAt >= profileUpdatedAt
+      ) {
+        return current
+      }
+
+      return profileToDraft(profile)
+    })
+  }, [profile?.id, profile?.updatedAt, hydration.isHydrated, profile])
+
+  const updateDraft = useCallback((patch: Partial<ProfileDraft>) => {
+    setDraft((current) => ({
+      ...current,
+      ...patch,
+      updatedAt: new Date().toISOString(),
+    }))
+  }, [])
+
+  const resetDraft = useCallback(async () => {
+    const base = profile ? profileToDraft(profile) : createEmptyDraft()
+    setDraft(base)
+    await localforage.removeItem(STORAGE_KEY)
+  }, [profile])
+
+  const applyProfile = useCallback(async (nextProfile: UserProfile) => {
+    const nextDraft = profileToDraft(nextProfile)
+    setDraft(nextDraft)
+    await localforage.setItem(STORAGE_KEY, nextDraft)
+  }, [])
+
+  const toUpdatePayload = useCallback((): ProfileUpdatePayload => {
+    const preferences = normalizePreferences(draft.preferences)
+    return {
+      fullName: draft.fullName || undefined,
+      headline: draft.headline || undefined,
+      bio: draft.bio || undefined,
+      interests: draft.interests.length ? draft.interests : undefined,
+      location: draft.location || undefined,
+      availability: draft.availability || undefined,
+      preferences,
+      photoUploadId: draft.photo?.uploadId,
+      avatarCacheKey: draft.photo?.avatarCacheKey,
+    }
+  }, [draft])
+
+  const toCreatePayload = useCallback((): ProfileCreatePayload => {
+    const preferences = normalizePreferences(draft.preferences)
+    return {
+      fullName: draft.fullName.trim(),
+      headline: draft.headline.trim(),
+      bio: draft.bio ? draft.bio.trim() : undefined,
+      interests: draft.interests,
+      location: draft.location || undefined,
+      availability: draft.availability || undefined,
+      preferences,
+      photoUploadId: draft.photo?.uploadId,
+      avatarCacheKey: draft.photo?.avatarCacheKey,
+    }
+  }, [draft])
+
+  const isDirty = useMemo(() => {
+    if (!profile) return true
+    const reference = profileToDraft(profile)
+    return !isEqual(reference, draft)
+  }, [draft, profile])
+
+  return {
+    draft,
+    updateDraft,
+    resetDraft,
+    applyProfile,
+    toUpdatePayload,
+    toCreatePayload,
+    hydration,
+    isDirty,
+  }
+}

--- a/src/features/profile/screens/ProfileEditScreen.tsx
+++ b/src/features/profile/screens/ProfileEditScreen.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useAuth } from '../../../auth/AuthContext'
+import { useAppStore } from '../../../store/AppStore'
+import ProfileForm from '../components/ProfileForm'
+import ProfilePhotoField from '../components/ProfilePhotoField'
+import type { ProfileFormErrors } from '../components/ProfileForm'
+import { useProfileDraft } from '../hooks/useProfileDraft'
+import { validateProfileDraft } from '../validation'
+
+const ProfileEditScreen: React.FC = () => {
+  const { token } = useAuth()
+  const { state, refreshProfile, saveProfile } = useAppStore()
+  const profile = state.profile.data
+  const {
+    draft,
+    updateDraft,
+    resetDraft,
+    applyProfile,
+    toUpdatePayload,
+    hydration,
+  } = useProfileDraft(profile, { waitForProfile: true })
+  const [validationErrors, setValidationErrors] = useState<ProfileFormErrors>({})
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const saveTaskRef = useRef<ReturnType<typeof saveProfile> | null>(null)
+
+  useEffect(() => {
+    if (state.profile.status === 'idle') {
+      void refreshProfile()
+    }
+  }, [state.profile.status, refreshProfile])
+
+  useEffect(() => {
+    return () => {
+      saveTaskRef.current?.cancel()
+    }
+  }, [])
+
+  const photoField = useMemo(
+    () => (
+      <ProfilePhotoField
+        token={token}
+        value={draft.photo}
+        onChange={(photo) => updateDraft({ photo })}
+        disabled={busy}
+      />
+    ),
+    [token, draft.photo, updateDraft, busy],
+  )
+
+  const handleSubmit = () => {
+    setError(null)
+    const validation = validateProfileDraft(draft)
+    setValidationErrors(validation.errors)
+    if (!validation.isValid) {
+      return
+    }
+
+    setValidationErrors({})
+    setBusy(true)
+    const payload = toUpdatePayload()
+    const task = saveProfile(payload, {
+      mode: 'update',
+      avatarCacheKey: draft.photo?.avatarCacheKey,
+      avatarPreviewUrl: draft.photo?.localUri,
+    })
+    saveTaskRef.current = task
+    task.promise
+      .then(() => {
+        setBusy(false)
+        saveTaskRef.current = null
+      })
+      .catch((reason) => {
+        setBusy(false)
+        saveTaskRef.current = null
+        setError((reason as Error).message)
+      })
+  }
+
+  const handleCancel = () => {
+    saveTaskRef.current?.cancel()
+    saveTaskRef.current = null
+    if (profile) {
+      void applyProfile(profile)
+    }
+    void resetDraft()
+  }
+
+  if (state.profile.status === 'loading' && !state.profile.data) {
+    return <div style={{ padding: 32 }}>Chargement du profil…</div>
+  }
+
+  if (state.profile.status === 'error') {
+    return (
+      <div style={{ padding: 32 }} role="alert">
+        Impossible de charger le profil.{' '}
+        <button type="button" onClick={refreshProfile}>
+          Réessayer
+        </button>
+      </div>
+    )
+  }
+
+  if (!state.profile.data) {
+    return <div style={{ padding: 32 }}>Profil introuvable</div>
+  }
+
+  if (!hydration.isHydrated) {
+    return <div style={{ padding: 32 }}>Chargement du brouillon…</div>
+  }
+
+  return (
+    <div style={{ padding: '40px 24px', background: '#f9fafb', minHeight: '100vh' }}>
+      <ProfileForm
+        mode="edit"
+        draft={draft}
+        onChange={updateDraft}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        busy={busy || state.profile.status === 'loading'}
+        error={error}
+        validationErrors={validationErrors}
+        photoField={photoField}
+      />
+    </div>
+  )
+}
+
+export default ProfileEditScreen


### PR DESCRIPTION
## Summary
- delay draft hydration until we have stored data or the latest profile to avoid wiping local edits
- update the edit screen to wait for hydrated drafts and reuse the new hook options

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d99f884c30833299934bff63b29eba