### PR TITLE
feat: add notification permission handling

### DIFF
--- a/src/features/discovery/screens/DiscoveryScreen.test.tsx
+++ b/src/features/discovery/screens/DiscoveryScreen.test.tsx
@@ -20,6 +20,8 @@ const baseStore = {
     matchFeedMeta: null,
     pendingMatchActions: [],
     matchNotifications: [],
+    messageNotifications: [],
+    notificationPermission: 'default',
   },
   refreshProfile: vi.fn(),
   saveProfile: vi.fn(),
@@ -33,6 +35,9 @@ const baseStore = {
   sendMessage: vi.fn(),
   setActiveConversation: vi.fn(),
   acknowledgeMatchNotification: vi.fn(),
+  acknowledgeMessageNotification: vi.fn(),
+  requestNotificationPermission: vi.fn(async () => 'default'),
+  ensureNotificationPermission: vi.fn(),
 }
 
 describe('DiscoveryScreen', () => {

--- a/src/features/events/__tests__/EventsFlow.test.tsx
+++ b/src/features/events/__tests__/EventsFlow.test.tsx
@@ -33,8 +33,10 @@ const createBaseStore = () => ({
     matchFeedMeta: null,
     pendingMatchActions: [],
     matchNotifications: [],
+    messageNotifications: [],
     eventDetails: {},
     pendingEventRegistrations: [],
+    notificationPermission: 'default',
   },
   refreshProfile: vi.fn(),
   saveProfile: vi.fn(),
@@ -49,6 +51,9 @@ const createBaseStore = () => ({
   sendMessage: vi.fn(),
   setActiveConversation: vi.fn(),
   acknowledgeMatchNotification: vi.fn(),
+  acknowledgeMessageNotification: vi.fn(),
+  requestNotificationPermission: vi.fn(async () => 'default'),
+  ensureNotificationPermission: vi.fn(),
 })
 
 describe('Events flow screens', () => {
@@ -201,7 +206,7 @@ describe('Events flow screens', () => {
       </MemoryRouter>,
     )
 
-    expect(screen.getByText(/Mode hors connexion/)).toBeInTheDocument()
+    expect(screen.getByText('Vous êtes hors ligne')).toBeInTheDocument()
     expect(screen.getByText('Atelier UX')).toBeInTheDocument()
 
     if (originalOnline) {

--- a/src/features/messaging/screens/MessagingScreen.test.tsx
+++ b/src/features/messaging/screens/MessagingScreen.test.tsx
@@ -34,6 +34,13 @@ const baseStore = {
     activeConversationId: null,
     pendingMessages: [],
     messagingRealtime: { status: 'connected', sessionId: 'session', since: new Date().toISOString(), presence: {} },
+    matchFeedMeta: null,
+    pendingMatchActions: [],
+    matchNotifications: [],
+    messageNotifications: [],
+    eventDetails: {},
+    pendingEventRegistrations: [],
+    notificationPermission: 'default',
   },
   refreshProfile: vi.fn(),
   saveProfile: vi.fn(),
@@ -49,6 +56,10 @@ const baseStore = {
   retryMessage: vi.fn(),
   setTypingState: vi.fn(),
   setActiveConversation: vi.fn(),
+  acknowledgeMatchNotification: vi.fn(),
+  acknowledgeMessageNotification: vi.fn(),
+  requestNotificationPermission: vi.fn(async () => 'default'),
+  ensureNotificationPermission: vi.fn(),
 }
 
 describe('MessagingScreen', () => {

--- a/src/features/profile/screens/ProfileScreen.test.tsx
+++ b/src/features/profile/screens/ProfileScreen.test.tsx
@@ -44,8 +44,10 @@ const createBaseState = (): AppState => ({
   matchFeedMeta: null,
   pendingMatchActions: [],
   matchNotifications: [],
+  messageNotifications: [],
   eventDetails: {},
   pendingEventRegistrations: [],
+  notificationPermission: 'default',
 })
 
 const createState = (overrides: Partial<AppState>): AppState => ({
@@ -69,6 +71,9 @@ type StoreStub = Pick<
     | 'sendMessage'
     | 'setActiveConversation'
     | 'acknowledgeMatchNotification'
+    | 'acknowledgeMessageNotification'
+    | 'requestNotificationPermission'
+    | 'ensureNotificationPermission'
 >
 
 const createStore = (overrides: Partial<StoreStub> = {}): StoreStub => {
@@ -86,6 +91,9 @@ const createStore = (overrides: Partial<StoreStub> = {}): StoreStub => {
     sendMessage: vi.fn(async () => {}),
     setActiveConversation: vi.fn(),
     acknowledgeMatchNotification: vi.fn(),
+    acknowledgeMessageNotification: vi.fn(),
+    requestNotificationPermission: vi.fn(async () => 'default'),
+    ensureNotificationPermission: vi.fn(),
   }
 
   return {

--- a/src/hooks/__tests__/useNotificationPermission.test.tsx
+++ b/src/hooks/__tests__/useNotificationPermission.test.tsx
@@ -1,0 +1,168 @@
+import { act, renderHook } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import useNotificationPermission from '../useNotificationPermission'
+import { AppStoreProvider } from '../../store/AppStore'
+
+const requestPermissionMock = vi.fn<Promise<NotificationPermission>, []>()
+
+vi.mock('../../auth/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'user-1', fullName: 'Jane Doe', headline: 'PM' },
+    token: null,
+    isAuthenticated: false,
+    isLoading: false,
+    login: vi.fn(),
+    setToken: vi.fn(),
+    logout: vi.fn(),
+  }),
+}))
+
+vi.mock('../../services/profileService', () => ({
+  default: {
+    getProfile: vi.fn(async () => null),
+    updateProfile: vi.fn(async () => {}),
+    getPreferences: vi.fn(async () => ({
+      discoveryRadiusKm: 25,
+      industries: [],
+      interests: [],
+      eventTypes: [],
+    })),
+  },
+}))
+
+vi.mock('../../services/matchingService', () => ({
+  default: {
+    getFeed: vi.fn(async () => ({ items: [], meta: { fetchedAt: new Date().toISOString(), nextCursor: null } })),
+    getStatus: vi.fn(async () => ({ liked: [], passed: [], matched: [], pending: [], updatedAt: new Date().toISOString() })),
+    syncLikes: vi.fn(async () => ({ processed: [], failed: [] })),
+    accept: vi.fn(),
+    decline: vi.fn(),
+  },
+}))
+
+vi.mock('../../services/eventsService', () => ({
+  default: {
+    list: vi.fn(async () => ({ items: [], page: 1, pageSize: 20, total: 0, hasMore: false })),
+    details: vi.fn(async () => undefined),
+    join: vi.fn(async () => {}),
+    leave: vi.fn(async () => {}),
+  },
+}))
+
+vi.mock('../../services/messagingService', () => ({
+  default: {
+    listConversations: vi.fn(async () => []),
+    listMessages: vi.fn(async () => []),
+    sendMessage: vi.fn(async () => ({
+      id: 'msg-1',
+      conversationId: 'conv-1',
+      senderId: 'user-2',
+      content: 'Hello',
+      createdAt: new Date().toISOString(),
+      status: 'sent',
+    })),
+    markConversationRead: vi.fn(async () => {}),
+  },
+}))
+
+vi.mock('../../services/realtimeMessaging', () => ({
+  createRealtimeMessaging: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    announcePresence: vi.fn(),
+    markConversationRead: vi.fn(),
+  })),
+}))
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <AppStoreProvider>{children}</AppStoreProvider>
+)
+
+const notificationMock: { permission: NotificationPermission; requestPermission: typeof requestPermissionMock } = {
+  permission: 'default',
+  requestPermission: requestPermissionMock,
+}
+
+const setNotificationPermission = (permission: NotificationPermission) => {
+  requestPermissionMock.mockReset()
+  requestPermissionMock.mockImplementation(async () => {
+    notificationMock.permission = permission
+    return permission
+  })
+  notificationMock.permission = permission
+}
+
+describe('useNotificationPermission', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'Notification', {
+      configurable: true,
+      writable: true,
+      value: notificationMock as unknown as typeof Notification,
+    })
+  })
+
+  afterEach(() => {
+    requestPermissionMock.mockReset()
+    delete (window as { Notification?: typeof Notification }).Notification
+  })
+
+  it('requests permission after a user interaction when state is default', async () => {
+    setNotificationPermission('default')
+
+    const { result } = renderHook(() => useNotificationPermission(), { wrapper })
+
+    expect(result.current.permission).toBe('default')
+    expect(requestPermissionMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      window.dispatchEvent(new Event('click'))
+      await Promise.resolve()
+    })
+
+    expect(requestPermissionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not request permission when already granted', async () => {
+    setNotificationPermission('granted')
+
+    renderHook(() => useNotificationPermission(), { wrapper })
+
+    await act(async () => {
+      window.dispatchEvent(new Event('click'))
+      await Promise.resolve()
+    })
+
+    expect(requestPermissionMock).not.toHaveBeenCalled()
+  })
+
+  it('does not request permission when denied', async () => {
+    setNotificationPermission('denied')
+
+    renderHook(() => useNotificationPermission(), { wrapper })
+
+    await act(async () => {
+      window.dispatchEvent(new Event('click'))
+      await Promise.resolve()
+    })
+
+    expect(requestPermissionMock).not.toHaveBeenCalled()
+  })
+
+  it('reports unsupported state when the Notification API is missing', async () => {
+    requestPermissionMock.mockReset()
+    delete (window as { Notification?: typeof Notification }).Notification
+
+    const { result } = renderHook(() => useNotificationPermission(), { wrapper })
+
+    expect(result.current.permission).toBe('unsupported')
+    expect(result.current.isSupported).toBe(false)
+
+    await act(async () => {
+      result.current.requestPermission()
+      await Promise.resolve()
+    })
+
+    expect(requestPermissionMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useNotificationPermission.ts
+++ b/src/hooks/useNotificationPermission.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect } from 'react'
+import { useAppStore } from '../store/AppStore'
+
+const useNotificationPermission = () => {
+  const {
+    state: { notificationPermission },
+    ensureNotificationPermission,
+    requestNotificationPermission,
+  } = useAppStore()
+
+  useEffect(() => {
+    if (notificationPermission === 'default') {
+      ensureNotificationPermission()
+    }
+  }, [notificationPermission, ensureNotificationPermission])
+
+  const requestPermission = useCallback(() => requestNotificationPermission(), [requestNotificationPermission])
+
+  return {
+    permission: notificationPermission,
+    isSupported: notificationPermission !== 'unsupported',
+    requestPermission,
+    ensurePermissionOnInteraction: ensureNotificationPermission,
+  }
+}
+
+export default useNotificationPermission

--- a/src/router/tabLayout.css
+++ b/src/router/tabLayout.css
@@ -44,6 +44,37 @@
   box-shadow: 0 -4px 12px rgba(15, 23, 42, 0.05);
 }
 
+.app-shell__notification {
+  margin: 0 var(--space-lg) var(--space-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-md);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: center;
+  box-shadow: var(--shadow-sm);
+}
+
+.app-shell__notification-content {
+  flex: 1;
+  min-width: 240px;
+}
+
+.app-shell__notification-preview {
+  margin: var(--space-xs) 0 0;
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+.app-shell__notification-actions {
+  display: inline-flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .app-shell__tab-link {
   text-decoration: none;
   color: inherit;
@@ -162,5 +193,16 @@
   .accessibility-menu__panel {
     right: auto;
     left: 0;
+  }
+
+  .app-shell__notification {
+    margin: 0 var(--space-md) var(--space-lg);
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app-shell__notification-actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `useNotificationPermission` hook and expose permission state through the app store
- update TabLayout to request permissions on interaction, show in-app fallbacks, and tweak styles
- adjust notification logic and tests, including a new hook unit test covering permission states

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68da03cb11548332a571c382c3b5abf8