### PR TITLE
Add enriched profile details to profile and match cards

### DIFF
--- a/src/features/discovery/__tests__/MatchCard.test.tsx
+++ b/src/features/discovery/__tests__/MatchCard.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import MatchCard from '../components/MatchCard'
+import type { MatchSuggestion } from '../types'
+
+describe('MatchCard', () => {
+  const suggestion: MatchSuggestion = {
+    id: 'match-1',
+    compatibilityScore: 0.92,
+    sharedInterests: ['Tech'],
+    profile: {
+      id: 'user-2',
+      fullName: 'John Smith',
+      headline: 'Développeur full-stack',
+      position: 'Lead Developer',
+      company: 'Meetinity',
+      bio: 'Toujours prêt à collaborer sur de nouveaux projets.',
+      interests: ['Tech', 'Randonnée'],
+      skills: ['React', 'TypeScript'],
+      links: [{ label: 'GitHub', url: 'https://github.com/johnsmith' }],
+    },
+  }
+
+  it('affiche les informations détaillées du match', () => {
+    render(<MatchCard suggestion={suggestion} />)
+
+    expect(screen.getByText('John Smith')).toBeInTheDocument()
+    expect(screen.getByText('Développeur full-stack')).toBeInTheDocument()
+    expect(screen.getByText('Lead Developer • Meetinity')).toBeInTheDocument()
+    expect(screen.getByText('Toujours prêt à collaborer sur de nouveaux projets.')).toBeInTheDocument()
+    expect(screen.getByText('React')).toBeInTheDocument()
+    expect(screen.getByText('TypeScript')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
+      'href',
+      'https://github.com/johnsmith',
+    )
+  })
+})

--- a/src/features/discovery/components/MatchCard.tsx
+++ b/src/features/discovery/components/MatchCard.tsx
@@ -16,18 +16,51 @@ const MatchCardComponent: React.FC<MatchCardProps> = ({ suggestion, onAccept, on
       </div>
       <div>
         <h3>{suggestion.profile.fullName}</h3>
-        <p className="card__subtitle">{suggestion.profile.headline}</p>
+        {suggestion.profile.headline && (
+          <p className="card__subtitle">{suggestion.profile.headline}</p>
+        )}
+        {(suggestion.profile.position || suggestion.profile.company) && (
+          <p className="card__subtitle">
+            {[suggestion.profile.position, suggestion.profile.company]
+              .filter(Boolean)
+              .join(' • ')}
+          </p>
+        )}
       </div>
       <span className="tag">{Math.round(suggestion.compatibilityScore * 100)}% match</span>
     </div>
     <div className="card__body">
-      <p>{suggestion.profile.bio}</p>
+      {suggestion.profile.bio && <p>{suggestion.profile.bio}</p>}
+      {suggestion.profile.skills && suggestion.profile.skills.length > 0 && (
+        <>
+          <strong>Compétences</strong>
+          <ul className="pill-list">
+            {suggestion.profile.skills.map((skill) => (
+              <li key={skill}>{skill}</li>
+            ))}
+          </ul>
+        </>
+      )}
       <strong>Intérêts communs</strong>
       <ul className="pill-list">
         {suggestion.sharedInterests.map((interest) => (
           <li key={interest}>{interest}</li>
         ))}
       </ul>
+      {suggestion.profile.links && suggestion.profile.links.length > 0 && (
+        <div>
+          <strong>Liens</strong>
+          <ul className="card__links">
+            {suggestion.profile.links.map((link) => (
+              <li key={link.url}>
+                <a href={link.url} target="_blank" rel="noreferrer">
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
     <div className="card__footer card__footer--actions">
       <button type="button" className="secondary" onClick={() => onDecline?.(suggestion.id)}>

--- a/src/features/messaging/types.ts
+++ b/src/features/messaging/types.ts
@@ -1,8 +1,14 @@
+import type { ProfileLink } from '../profile/types'
+
 export interface Participant {
   id: string
   fullName: string
   avatarUrl?: string
   headline?: string
+  company?: string
+  position?: string
+  skills?: string[]
+  links?: ProfileLink[]
 }
 
 export interface Attachment {

--- a/src/features/profile/__tests__/ProfileCard.test.tsx
+++ b/src/features/profile/__tests__/ProfileCard.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import ProfileCard from '../components/ProfileCard'
+import type { UserProfile } from '../types'
+
+describe('ProfileCard', () => {
+  const profile: UserProfile = {
+    id: 'user-1',
+    fullName: 'Jane Doe',
+    headline: 'Cheffe de produit',
+    position: 'Product Manager',
+    company: 'Meetinity',
+    bio: 'Passionnée par la création de communautés.',
+    avatarUrl: 'https://example.com/avatar.jpg',
+    interests: ['Networking', 'Tech'],
+    skills: ['Leadership', 'Design'],
+    links: [
+      { label: 'LinkedIn', url: 'https://linkedin.com/in/janedoe' },
+      { label: 'Portfolio', url: 'https://janedoe.dev' },
+    ],
+    preferences: {
+      discoveryRadiusKm: 10,
+      industries: ['Tech'],
+      interests: ['Networking'],
+      eventTypes: ['Meetup'],
+    },
+  }
+
+  it('affiche les informations enrichies du profil', () => {
+    render(<ProfileCard profile={profile} />)
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('Cheffe de produit')).toBeInTheDocument()
+    expect(screen.getByText('Product Manager • Meetinity')).toBeInTheDocument()
+    expect(screen.getByText('Passionnée par la création de communautés.')).toBeInTheDocument()
+    expect(screen.getByText('Leadership')).toBeInTheDocument()
+    expect(screen.getByText('Design')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute(
+      'href',
+      'https://linkedin.com/in/janedoe',
+    )
+    expect(screen.getByRole('link', { name: 'Portfolio' })).toHaveAttribute(
+      'href',
+      'https://janedoe.dev',
+    )
+  })
+})

--- a/src/features/profile/components/ProfileCard.tsx
+++ b/src/features/profile/components/ProfileCard.tsx
@@ -25,7 +25,12 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ profile, preferences, onEdit 
         )}
         <div>
           <h2>{profile.fullName}</h2>
-          <p className="card__subtitle">{profile.headline}</p>
+          {profile.headline && <p className="card__subtitle">{profile.headline}</p>}
+          {(profile.position || profile.company) && (
+            <p className="card__subtitle">
+              {[profile.position, profile.company].filter(Boolean).join(' • ')}
+            </p>
+          )}
         </div>
         {onEdit && (
           <button type="button" className="card__action" onClick={onEdit}>
@@ -43,6 +48,16 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ profile, preferences, onEdit 
             ))}
           </ul>
         </div>
+        {profile.skills && profile.skills.length > 0 && (
+          <div>
+            <strong>Compétences</strong>
+            <ul className="pill-list">
+              {profile.skills.map((skill) => (
+                <li key={skill}>{skill}</li>
+              ))}
+            </ul>
+          </div>
+        )}
         {profile.location && (
           <div>
             <strong>Localisation</strong>
@@ -53,6 +68,20 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ profile, preferences, onEdit 
           <div>
             <strong>Disponibilités</strong>
             <p>{profile.availability}</p>
+          </div>
+        )}
+        {profile.links && profile.links.length > 0 && (
+          <div>
+            <strong>Liens</strong>
+            <ul className="card__links">
+              {profile.links.map((link) => (
+                <li key={link.url}>
+                  <a href={link.url} target="_blank" rel="noreferrer">
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
           </div>
         )}
         {resolvedPreferences && (

--- a/src/features/shared.css
+++ b/src/features/shared.css
@@ -102,6 +102,25 @@ section h1 {
   font-weight: var(--font-weight-medium);
 }
 
+.card__links {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-xs) 0 0;
+  display: grid;
+  gap: var(--space-2xs);
+}
+
+.card__links a {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: var(--font-weight-medium);
+}
+
+.card__links a:hover,
+.card__links a:focus {
+  text-decoration: underline;
+}
+
 .tag {
   background: rgba(108, 92, 231, 0.12);
   color: var(--color-primary);


### PR DESCRIPTION
## Summary
- display company, position, skills, and external links on profile and discovery match cards
- normalize stored match data so messaging and discovery flows receive the enriched profile attributes
- add focused rendering tests covering the new profile fields and link styling helpers

## Testing
- npm run test -- --run src/features/profile/__tests__/ProfileCard.test.tsx src/features/discovery/__tests__/MatchCard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da3afc39f483329871dccb8efc94eb