### PR TITLE
Add validation to profile editor and extend tests

### DIFF
--- a/src/features/profile/screens/ProfileScreen.test.tsx
+++ b/src/features/profile/screens/ProfileScreen.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import React from 'react'
 import { vi } from 'vitest'
 import ProfileScreen from './ProfileScreen'
 import type { AppState, AppStoreValue } from '../../../store/AppStore'
+import { appCache } from '../../../lib/cache'
 
 const mockUseAppStore = vi.fn()
 const getPreferencesMock = vi.fn().mockResolvedValue({
@@ -106,6 +107,7 @@ const createStore = (overrides: Partial<StoreStub> = {}): StoreStub => {
 describe('ProfileScreen', () => {
   beforeEach(() => {
     mockUseAppStore.mockReset()
+    appCache.clear()
   })
 
   it('render loading state while profile is being fetched', () => {
@@ -147,5 +149,72 @@ describe('ProfileScreen', () => {
     fireEvent.click(screen.getByText('Modifier'))
 
     expect(screen.getByLabelText('Nom complet')).toHaveValue('Jane Doe')
+  })
+
+  it('blocks saving and shows validation errors when the form is invalid', async () => {
+    const saveProfile = vi.fn().mockResolvedValue(undefined)
+    const profileWithPreferences = {
+      ...profile,
+      preferences: { discoveryRadiusKm: 20, industries: [], interests: [], eventTypes: [] },
+    }
+
+    mockUseAppStore.mockReturnValue(
+      createStore({
+        state: createState({ profile: { status: 'success', data: profileWithPreferences } }),
+        saveProfile,
+      }),
+    )
+
+    render(<ProfileScreen />)
+
+    fireEvent.click(screen.getByText('Modifier'))
+
+    fireEvent.change(screen.getByLabelText('Nom complet'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Titre'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Bio'), { target: { value: 'a'.repeat(350) } })
+    fireEvent.change(screen.getByLabelText('Intérêts (séparés par des virgules)'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Rayon de découverte (km)'), { target: { value: '-5' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ajouter un lien' }))
+    const linksFieldset = await screen.findByRole('group', { name: 'Liens publics' })
+    const linkLabelInput = within(linksFieldset).getByLabelText('Libellé')
+    const linkUrlInput = within(linksFieldset).getByLabelText('URL')
+    fireEvent.change(linkLabelInput, { target: { value: 'Portfolio' } })
+    fireEvent.change(linkUrlInput, { target: { value: 'notaurl' } })
+
+    expect(screen.getByText('La bio ne doit pas dépasser 280 caractères.')).toBeInTheDocument()
+
+    fireEvent.submit(screen.getByRole('form', { name: 'Édition du profil' }))
+
+    expect(saveProfile).not.toHaveBeenCalled()
+    expect(screen.getByText('Le nom complet est requis.')).toBeInTheDocument()
+    expect(screen.getByText('Le titre est requis.')).toBeInTheDocument()
+    expect(screen.getByText('Ajoutez au moins un intérêt.')).toBeInTheDocument()
+    expect(screen.getByText("L'URL doit être valide.")).toBeInTheDocument()
+    expect(screen.getByText('Indiquez un rayon valide (en kilomètres).')).toBeInTheDocument()
+  })
+
+  it('saves the profile when the form passes validation', async () => {
+    const saveProfile = vi.fn().mockResolvedValue(undefined)
+
+    mockUseAppStore.mockReturnValue(
+      createStore({
+        saveProfile,
+        state: createState({ profile: { status: 'success', data: { ...profile, preferences: null } } }),
+      }),
+    )
+
+    render(<ProfileScreen />)
+
+    fireEvent.click(screen.getByText('Modifier'))
+
+    fireEvent.change(screen.getByLabelText('Nom complet'), { target: { value: 'Jane Updated' } })
+    fireEvent.change(screen.getByLabelText('Titre'), { target: { value: 'Head of Product' } })
+    fireEvent.change(screen.getByLabelText('Bio'), { target: { value: 'Bio mise à jour' } })
+    fireEvent.change(screen.getByLabelText('Rayon de découverte (km)'), { target: { value: '30' } })
+
+    fireEvent.submit(screen.getByRole('form', { name: 'Édition du profil' }))
+
+    await waitFor(() => expect(saveProfile).toHaveBeenCalled())
   })
 })

--- a/src/features/profile/validation.ts
+++ b/src/features/profile/validation.ts
@@ -1,0 +1,104 @@
+import type { ProfileDraft, ProfileLink } from './types'
+
+export const BIO_MAX_LENGTH = 280
+
+export interface ProfileLinkValidationErrors {
+  label?: string
+  url?: string
+}
+
+export interface ProfileValidationErrors {
+  fullName?: string
+  headline?: string
+  bio?: string
+  interests?: string
+  discoveryRadiusKm?: string
+  links?: Array<ProfileLinkValidationErrors | undefined>
+}
+
+export interface ProfileValidationResult {
+  isValid: boolean
+  errors: ProfileValidationErrors
+}
+
+const isNonEmpty = (value: string | undefined | null): boolean => {
+  if (value == null) return false
+  return value.trim().length > 0
+}
+
+const hasLinkContent = (link: ProfileLink): boolean => {
+  const label = link.label ?? ''
+  const url = link.url ?? ''
+  return label.trim().length > 0 || url.trim().length > 0
+}
+
+const isValidHttpUrl = (value: string): boolean => {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export const validateProfileDraft = (draft: ProfileDraft): ProfileValidationResult => {
+  const errors: ProfileValidationErrors = {}
+
+  if (!isNonEmpty(draft.profile.fullName)) {
+    errors.fullName = 'Le nom complet est requis.'
+  }
+
+  if (!isNonEmpty(draft.profile.headline)) {
+    errors.headline = 'Le titre est requis.'
+  }
+
+  const interests = draft.profile.interests ?? []
+  const hasInterests = interests.some((interest) => interest.trim().length > 0)
+  if (!hasInterests) {
+    errors.interests = 'Ajoutez au moins un intérêt.'
+  }
+
+  const bioLength = draft.profile.bio?.length ?? 0
+  if (bioLength > BIO_MAX_LENGTH) {
+    errors.bio = `La bio ne doit pas dépasser ${BIO_MAX_LENGTH} caractères.`
+  }
+
+  const radius = draft.preferences.discoveryRadiusKm
+  if (radius != null) {
+    if (!Number.isFinite(radius) || radius <= 0) {
+      errors.discoveryRadiusKm = 'Indiquez un rayon valide (en kilomètres).'
+    }
+  }
+
+  const links = draft.profile.links ?? []
+  const linkErrors = links.map<ProfileLinkValidationErrors | undefined>((link) => {
+    if (!hasLinkContent(link)) {
+      return undefined
+    }
+
+    const trimmedLabel = link.label?.trim() ?? ''
+    const trimmedUrl = link.url?.trim() ?? ''
+    const entryErrors: ProfileLinkValidationErrors = {}
+
+    if (trimmedLabel.length === 0) {
+      entryErrors.label = 'Ajoutez un libellé.'
+    }
+
+    if (trimmedUrl.length === 0) {
+      entryErrors.url = 'Ajoutez une URL.'
+    } else if (!isValidHttpUrl(trimmedUrl)) {
+      entryErrors.url = "L'URL doit être valide."
+    }
+
+    return Object.keys(entryErrors).length > 0 ? entryErrors : undefined
+  })
+
+  if (linkErrors.some((error) => error !== undefined)) {
+    errors.links = linkErrors
+  }
+
+  return {
+    errors,
+    isValid: Object.keys(errors).length === 0,
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable profile draft validation schema to enforce required fields, bio length, discovery radius and link URL formats
- surface localized validation errors inside ProfileEditor and block invalid form submissions
- extend ProfileEditor and ProfileScreen test suites to cover validation success/failure and error rendering

## Testing
- `node node_modules/vitest/vitest.mjs run src/features/profile/__tests__/ProfileEditor.test.tsx src/features/profile/screens/ProfileScreen.test.tsx --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_68da43370c488332beebf1634dde292d